### PR TITLE
adding method rewrite proof-of-concept 2 (electric boogaloo)

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -109,7 +109,8 @@ trait SilFrontend extends DefaultFrontend {
    */
   private val defaultPlugins: Seq[String] = Seq(
     "viper.silver.plugin.standard.termination.TerminationPlugin",
-    "viper.silver.plugin.standard.predicateinstance.PredicateInstancePlugin"
+    "viper.silver.plugin.standard.predicateinstance.PredicateInstancePlugin",
+    "viper.silver.plugin.standard.inline.InlinePredicatePlugin",
   )
 
 

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -1,6 +1,9 @@
 package viper.silver.plugin.standard.inline
 
+import viper.silver.ast.utility.ViperStrategy
+import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.ast.{Exp, LocalVar, Method, Node, PredicateAccess, Program}
+import viper.silver.plugin.standard.predicateinstance.PredicateInstance
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 
 class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate {
@@ -12,7 +15,11 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate {
     val methodsWithExpandedPres = declaredMethods.map(expandPreconditions(_, input))
 
     // TODO: actually rewrite program with methods with expanded predicates
-    input
+    val rewrittenProgram = ViperStrategy.Slim({
+      case program: Program =>
+        program.copy(methods = methodsWithExpandedPres)(program.pos, program.info, program.errT)
+    }, Traverse.BottomUp).execute(input)
+    rewrittenProgram
   }
 
   private[this] def expandPreconditions(method: Method, program: Program): Method = {

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -2,48 +2,23 @@ package viper.silver.plugin.standard.inline
 
 import viper.silver.ast.utility.ViperStrategy
 import viper.silver.ast.utility.rewriter.Traverse
-import viper.silver.ast.{Exp, LocalVar, Method, Node, PredicateAccess, Program}
-import viper.silver.plugin.standard.predicateinstance.PredicateInstance
+import viper.silver.ast.Program
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 
-class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate {
+class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate with InlineRewrite {
 
   private[this] val InlinePredicateKeyword = "inline"
 
   override def beforeVerify(input: Program): Program = {
     val declaredMethods = input.methods
-    val methodsWithExpandedPres = declaredMethods.map(expandPreconditions(_, input))
+    val methodsWithInlinedPreds = declaredMethods.map(inlinePredicates(_, input))
+    val rewrittenMethods = methodsWithInlinedPreds.map(removeUnfoldFold(_, input))
 
     // TODO: actually rewrite program with methods with expanded predicates
     val rewrittenProgram = ViperStrategy.Slim({
       case program: Program =>
-        program.copy(methods = methodsWithExpandedPres)(program.pos, program.info, program.errT)
+        program.copy(methods = rewrittenMethods)(program.pos, program.info, program.errT)
     }, Traverse.BottomUp).execute(input)
     rewrittenProgram
   }
-
-  private[this] def expandPreconditions(method: Method, program: Program): Method = {
-    method.copy(name = method.name,
-      formalArgs = method.formalArgs,
-      formalReturns = method.formalReturns,
-      pres = method.pres.map { pre =>
-        expandPred(pre, program).fold(pre)(expandedPred => expandedPred)
-      },
-      posts = method.posts,
-      body = method.body
-    )(pos = method.pos, info = method.info, errT = method.errT)
-  }
-
-  private[this] def expandPred(expr: Exp, program: Program): Option[Exp] = expr match {
-    case pred: PredicateAccess =>
-      val args = getLocalVarNames(pred)
-      pred.predicateBody(program, args)
-    case _:_ => None
-  }
-
-  private[this] def getLocalVarNames(predicate: PredicateAccess): Set[String] =
-    predicate.args.map {
-      case arg: LocalVar => arg.name
-      case _: _ => ""
-    }.filterNot(_ == "").toSet
 }

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -1,0 +1,42 @@
+package viper.silver.plugin.standard.inline
+
+import viper.silver.ast.{Exp, LocalVar, Method, Node, PredicateAccess, Program}
+import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
+
+class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate {
+
+  private[this] val InlinePredicateKeyword = "inline"
+
+  override def beforeVerify(input: Program): Program = {
+    val declaredMethods = input.methods
+    val methodsWithExpandedPres = declaredMethods.map(expandPreconditions(_, input))
+
+    // TODO: actually rewrite program with methods with expanded predicates
+    input
+  }
+
+  private[this] def expandPreconditions(method: Method, program: Program): Method = {
+    method.copy(name = method.name,
+      formalArgs = method.formalArgs,
+      formalReturns = method.formalReturns,
+      pres = method.pres.map { pre =>
+        expandPred(pre, program).fold(pre)(expandedPred => expandedPred)
+      },
+      posts = method.posts,
+      body = method.body
+    )(pos = method.pos, info = method.info, errT = method.errT)
+  }
+
+  private[this] def expandPred(expr: Exp, program: Program): Option[Exp] = expr match {
+    case pred: PredicateAccess =>
+      val args = getLocalVarNames(pred)
+      pred.predicateBody(program, args)
+    case _:_ => None
+  }
+
+  private[this] def getLocalVarNames(predicate: PredicateAccess): Set[String] =
+    predicate.args.map {
+      case arg: LocalVar => arg.name
+      case _: _ => ""
+    }.filterNot(_ == "").toSet
+}

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -1,7 +1,5 @@
 package viper.silver.plugin.standard.inline
 
-import viper.silver.ast.utility.ViperStrategy
-import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.ast.Program
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 
@@ -10,15 +8,19 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate with 
   private[this] val InlinePredicateKeyword = "inline"
 
   override def beforeVerify(input: Program): Program = {
-    val declaredMethods = input.methods
-    val methodsWithInlinedPreds = declaredMethods.map(inlinePredicates(_, input))
-    val rewrittenMethods = methodsWithInlinedPreds.map(removeUnfoldFold(_, input))
+     val inlinedPredicateMethods = input.methods.map(inlinePredicates(_, input))
 
-    // TODO: actually rewrite program with methods with expanded predicates
-    val rewrittenProgram = ViperStrategy.Slim({
-      case program: Program =>
-        program.copy(methods = rewrittenMethods)(program.pos, program.info, program.errT)
-    }, Traverse.BottomUp).execute(input)
-    rewrittenProgram
+    println(s"METHODS BEFORE")
+    println(s"${input.methods}")
+    println(s"METHODS AFTER")
+    println(s"$inlinedPredicateMethods")
+
+//
+//    val newProgram: Program = ViperStrategy.Slim({
+//      case p: Program =>
+//        p.copy(predicates = Seq())(p.pos, p.info, p.errT)
+//    }, Traverse.BottomUp).execute(input)
+//    println(s"After removing predicates: $newProgram")
+    input
   }
 }

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -8,12 +8,14 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate with 
   private[this] val InlinePredicateKeyword = "inline"
 
   override def beforeVerify(input: Program): Program = {
-     val inlinedPredicateMethods = input.methods.map(inlinePredicates(_, input))
+    val expandablePredicateIds = collectExpandablePredicateIds(input.methods, input)
+    val inlinedPredicateMethods = input.methods.map(inlinePredicates(_, input))
+    val foldUnfoldRemoved = inlinedPredicateMethods.map(removeUnfoldFold(_, expandablePredicateIds))
 
-    println(s"METHODS BEFORE")
+    println(s"METHODS BEFORE INLINING")
     println(s"${input.methods}")
-    println(s"METHODS AFTER")
-    println(s"$inlinedPredicateMethods")
+    println(s"METHODS AFTER INLINING")
+    println(s"$foldUnfoldRemoved")
 
 //
 //    val newProgram: Program = ViperStrategy.Slim({

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -1,6 +1,8 @@
 package viper.silver.plugin.standard.inline
 
 import viper.silver.ast.Program
+import viper.silver.ast.utility.ViperStrategy
+import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 
 class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate with InlineRewrite {
@@ -17,12 +19,12 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate with 
     println(s"METHODS AFTER INLINING")
     println(s"$foldUnfoldRemoved")
 
-//
-//    val newProgram: Program = ViperStrategy.Slim({
-//      case p: Program =>
-//        p.copy(predicates = Seq())(p.pos, p.info, p.errT)
-//    }, Traverse.BottomUp).execute(input)
-//    println(s"After removing predicates: $newProgram")
-    input
+
+    val newProgram: Program = ViperStrategy.Slim({
+      case p: Program =>
+        p.copy(methods = foldUnfoldRemoved)(p.pos, p.info, p.errT)
+    }, Traverse.BottomUp).execute(input)
+    println(s"After removing predicates:\n $newProgram")
+    newProgram
   }
 }

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -1,0 +1,79 @@
+package viper.silver.plugin.standard.inline
+
+import viper.silver.ast.{Exp, Fold, LocalVar, Method, PredicateAccess, Program, Stmt, Unfold}
+
+trait InlineRewrite {
+
+  def inlinePredicates(method: Method, program: Program): Method = {
+    val expandedPres = method.pres.map { pre =>
+      expandPredicate(pre, program).fold(pre)(expandedPred => expandedPred)
+    }
+    val expandedPosts = method.posts.map { post =>
+      expandPredicate(post, program).fold(post)(expandedPred => expandedPred)
+    }
+    method.copy(name = method.name,
+      formalArgs = method.formalArgs,
+      formalReturns = method.formalReturns,
+      pres = expandedPres,
+      posts = expandedPosts,
+      body = method.body
+    )(pos = method.pos, info = method.info, errT = method.errT)
+  }
+
+  def removeUnfoldFold(method: Method, program: Program): Method = {
+    val expandablePredicateIds = getExpandablePredicateIds(method.pres, program)
+    val rewrittenBody = method.body.map { body =>
+      val bodyWithRemovedUnfolds = removeUnfolds(body.ss, expandablePredicateIds)
+      val bodyWithRemovedUnfoldFolds = removeFolds(bodyWithRemovedUnfolds, expandablePredicateIds)
+      body.copy(ss = bodyWithRemovedUnfoldFolds, scopedDecls = body.scopedDecls)(
+        pos = body.pos, info = body.info, errT = body.errT
+      )
+    }
+    method.copy(name = method.name,
+      formalArgs = method.formalArgs,
+      formalReturns = method.formalReturns,
+      pres = method.pres,
+      posts = method.posts,
+      body = rewrittenBody
+    )(pos = method.pos, info = method.info, errT = method.errT)
+  }
+
+  private[this] def expandPredicate(expr: Exp, program: Program): Option[Exp] =
+    expr match {
+      case pred: PredicateAccess => getPredicateBody(pred, program)
+      case _ => None
+    }
+
+  private[this] def getPredicateBody(pred: PredicateAccess, program: Program): Option[Exp] = {
+    def extractLocalVarIds(predicate: PredicateAccess): Set[String] =
+      predicate.args.map {
+        case arg: LocalVar => arg.name
+        case _ => ""
+      }.filter(_.nonEmpty).toSet
+
+    val args = extractLocalVarIds(pred)
+    pred.predicateBody(program, args)
+  }
+
+  private[this] def getExpandablePredicateIds(exprs: Seq[Exp], program: Program): Seq[String] =
+    exprs.collect {
+      case exp: PredicateAccess if getPredicateBody(exp, program).nonEmpty => exp.predicateName
+  }
+
+  private[this] def removeUnfolds(bodyStmts: Seq[Stmt], predicatesToRemove: Seq[String]): Seq[Stmt] =
+    bodyStmts.filter {
+      case unfoldExp: Unfold =>
+        val unfoldPredName = unfoldExp.acc.loc.predicateName
+        predicatesToRemove.contains(unfoldPredName)
+      case _ => false
+    }
+
+  private[this] def removeFolds(bodyStmts: Seq[Stmt], predicatesToRemove: Seq[String]): Seq[Stmt] = {
+    bodyStmts.filter {
+      case foldExp: Fold =>
+        val foldPredName = foldExp.acc.loc.predicateName
+        predicatesToRemove.contains(foldPredName)
+      case _ => false
+    }
+  }
+}

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -1,6 +1,6 @@
 package viper.silver.plugin.standard.inline
 
-import viper.silver.ast.{Exp, Fold, LocalVar, Method, PredicateAccess, Program, Stmt, Unfold}
+import viper.silver.ast.{Exp, Fold, LocalVar, Method, PredicateAccess, PredicateAccessPredicate, Program, Seqn, Stmt, Unfold}
 
 trait InlineRewrite {
 
@@ -8,14 +8,14 @@ trait InlineRewrite {
     val expandedPres = method.pres.map { pre =>
       expandPredicate(pre, program).fold(pre)(expandedPred => expandedPred)
     }
-    val expandedPosts = method.posts.map { post =>
-      expandPredicate(post, program).fold(post)(expandedPred => expandedPred)
-    }
+//    val expandedPosts = method.posts.map { post =>
+//      expandPredicate(post, program).fold(post)(expandedPred => expandedPred)
+//    }
     method.copy(name = method.name,
       formalArgs = method.formalArgs,
       formalReturns = method.formalReturns,
       pres = expandedPres,
-      posts = expandedPosts,
+      posts = method.posts,
       body = method.body
     )(pos = method.pos, info = method.info, errT = method.errT)
   }
@@ -24,10 +24,13 @@ trait InlineRewrite {
     val expandablePredicateIds = getExpandablePredicateIds(method.pres, program)
     val rewrittenBody = method.body.map { body =>
       val bodyWithRemovedUnfolds = removeUnfolds(body.ss, expandablePredicateIds)
-      val bodyWithRemovedUnfoldFolds = removeFolds(bodyWithRemovedUnfolds, expandablePredicateIds)
-      body.copy(ss = bodyWithRemovedUnfoldFolds, scopedDecls = body.scopedDecls)(
-        pos = body.pos, info = body.info, errT = body.errT
+      body.copy(ss = bodyWithRemovedUnfolds, scopedDecls = body.scopedDecls)(
+              pos = body.pos, info = body.info, errT = body.errT
       )
+//      val bodyWithRemovedUnfoldFolds = removeFolds(bodyWithRemovedUnfolds, expandablePredicateIds)
+//      body.copy(ss = bodyWithRemovedUnfoldFolds, scopedDecls = body.scopedDecls)(
+//        pos = body.pos, info = body.info, errT = body.errT
+//      )
     }
     method.copy(name = method.name,
       formalArgs = method.formalArgs,
@@ -40,7 +43,8 @@ trait InlineRewrite {
 
   private[this] def expandPredicate(expr: Exp, program: Program): Option[Exp] =
     expr match {
-      case pred: PredicateAccess => getPredicateBody(pred, program)
+      case PredicateAccessPredicate(pred, _) =>
+        getPredicateBody(pred, program)
       case _ => None
     }
 
@@ -55,18 +59,24 @@ trait InlineRewrite {
     pred.predicateBody(program, args)
   }
 
-  private[this] def getExpandablePredicateIds(exprs: Seq[Exp], program: Program): Seq[String] =
+  private[this] def getExpandablePredicateIds(exprs: Seq[Exp], program: Program): Seq[String] = {
+    println(exprs)
     exprs.collect {
-      case exp: PredicateAccess if getPredicateBody(exp, program).nonEmpty => exp.predicateName
+      case PredicateAccessPredicate(pred, _) if getPredicateBody(pred, program).nonEmpty => pred.predicateName
+    }
   }
 
-  private[this] def removeUnfolds(bodyStmts: Seq[Stmt], predicatesToRemove: Seq[String]): Seq[Stmt] =
+  private[this] def removeUnfolds(bodyStmts: Seq[Stmt], predicatesToRemove: Seq[String]): Seq[Stmt] = {
+    println(s"predicates to remove: $predicatesToRemove")
     bodyStmts.filter {
-      case unfoldExp: Unfold =>
-        val unfoldPredName = unfoldExp.acc.loc.predicateName
-        predicatesToRemove.contains(unfoldPredName)
-      case _ => false
+      case sequenceOfStmt: Seqn =>
+        sequenceOfStmt.exists {
+          case Unfold(pred) => !predicatesToRemove.contains(pred.loc.predicateName)
+        }
+        true
+      case _ => true
     }
+  }
 
   private[this] def removeFolds(bodyStmts: Seq[Stmt], predicatesToRemove: Seq[String]): Seq[Stmt] = {
     bodyStmts.filter {


### PR DESCRIPTION
This one enforces a cleaner separation of concerns by moving rewrite logic into a separate trait.

This also (I think) removes `fold` and `unfold` statements when possible.