### PR TITLE
Adding temporary branch for demo

### DIFF
--- a/demo/mutrec.vpr
+++ b/demo/mutrec.vpr
@@ -1,0 +1,11 @@
+field elem: Int
+field next: Ref
+
+predicate foo(this: Ref) {
+  list(this) && acc(this.elem)
+}
+
+predicate list(this: Ref) {
+  acc(this.elem) && acc(this.next) &&
+  (this.next != null ==> foo(this.next))
+}

--- a/demo/mutrec.vpr
+++ b/demo/mutrec.vpr
@@ -1,11 +1,13 @@
 field elem: Int
 field next: Ref
 
-predicate foo(this: Ref) {
+predicate foo(this: Ref) 
+{
   list(this) && acc(this.elem)
 }
 
-predicate list(this: Ref) {
-  acc(this.elem) && acc(this.next) &&
-  (this.next != null ==> foo(this.next))
+predicate list(this: Ref) 
+{
+  acc(this.elem) && acc(this.next) && 
+    (this.next != null ==> foo(this.next))
 }

--- a/demo/norec.vpr
+++ b/demo/norec.vpr
@@ -1,6 +1,7 @@
 field left: Int
 field right: Int
 
-predicate norec(this: Ref) {
+predicate norec(this: Ref) 
+{
   acc(this.left) && acc(this.right)
 }

--- a/demo/norec.vpr
+++ b/demo/norec.vpr
@@ -1,0 +1,6 @@
+field left: Int
+field right: Int
+
+predicate norec(this: Ref) {
+  acc(this.left) && acc(this.right)
+}

--- a/demo/recursive.vpr
+++ b/demo/recursive.vpr
@@ -1,7 +1,8 @@
 field elem: Int
 field next: Ref
 
-predicate list(this: Ref) {
-  acc(this.elem) && acc(this.next) &&
-  (this.next != null ==> list(this.next))
+predicate list(this: Ref) 
+{
+  acc(this.elem) && acc(this.next) && 
+    (this.next != null ==> list(this.next))
 }

--- a/demo/recursive.vpr
+++ b/demo/recursive.vpr
@@ -1,0 +1,7 @@
+field elem: Int
+field next: Ref
+
+predicate list(this: Ref) {
+  acc(this.elem) && acc(this.next) &&
+  (this.next != null ==> list(this.next))
+}

--- a/demo/sum.vpr
+++ b/demo/sum.vpr
@@ -1,0 +1,22 @@
+predicate nonZero(k: Int)
+{
+  0 <= k
+}
+
+
+method sum(n: Int) returns (res: Int)
+  requires nonZero(n) 
+  ensures  res == n * (n + 1) / 2
+{
+  unfold nonZero(n)
+  res := 0
+  var i: Int := 0;
+  while(i <= n)
+    invariant i <= (n + 1)
+    invariant res == (i - 1) * i / 2
+  {
+    res := res + i
+    i := i + 1
+  }
+  fold nonZero(n)
+}

--- a/demo/sum.vpr
+++ b/demo/sum.vpr
@@ -1,14 +1,14 @@
-predicate nonZero(k: Int)
+predicate nonNeg(k: Int)
 {
   0 <= k
 }
 
 
 method sum(n: Int) returns (res: Int)
-  requires nonZero(n) 
+  requires nonNeg(n) 
   ensures  res == n * (n + 1) / 2
 {
-  unfold nonZero(n)
+  unfold nonNeg(n)
   res := 0
   var i: Int := 0;
   while(i <= n)
@@ -18,5 +18,5 @@ method sum(n: Int) returns (res: Int)
     res := res + i
     i := i + 1
   }
-  fold nonZero(n)
+  fold nonNeg(n)
 }

--- a/demo/tuple.vpr
+++ b/demo/tuple.vpr
@@ -1,0 +1,16 @@
+field left: Int
+field right: Int
+
+predicate allowAccess(this: Ref)
+{
+	acc(this.left) && acc(this.right)
+}
+
+method makeTuple(this: Ref, i: Int, j: Int)
+	requires allowAccess(this)
+{
+	unfold allowAccess(this)
+	this.left := this.left + i
+	this.right := this.right + j
+	fold allowAccess(this)
+}

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -35,12 +35,25 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
       rewriteMethod(inlinedPredMethod, input, prePredIds, postPredIds)
     }
     // TODO: Do we also need to rewrite functions?
-    ViperStrategy.Slim({
-      case program@Program(_, _, _, predicates, methods, extensions) =>
+    val rewrittenProgram = ViperStrategy.Slim({
+      case program@Program(_, _, _, predicates, _, extensions) =>
         program.copy(
           methods = rewrittenMethods,
-          predicates = predicates ++ extensions.collect{case InlinePredicate(p) => p},  
+          predicates = predicates ++ extensions.collect{case InlinePredicate(p) => p},
         )(program.pos, program.info, program.errT)
     }).execute[Program](input)
+
+    // Added for demo
+    printPrograms(input, rewrittenProgram)
+    rewrittenProgram
+  }
+
+  private[this] def printPrograms(beforeInline: Program, afterInline: Program): Unit = {
+    println(s"============ INPUT PROGRAM ============")
+    println(s"$beforeInline")
+    println(s"========== END INPUT PROGRAM ==========")
+    println(s"========== REWRITTEN PROGRAM ==========")
+    println(s"$afterInline")
+    println(s"======== END REWRITTEN PROGRAM ========")
   }
 }

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -26,7 +26,8 @@ trait InlineRewrite {
   def rewriteMethod(method: Method, program: Program, prePredIds: Set[String], postPredIds: Set[String]): Method = {
     val rewrittenPres = method.pres.map { removeUnfoldings(_, prePredIds) }
     val rewrittenPosts = method.posts.map { removeUnfoldings(_, postPredIds) }
-    val rewrittenBody = method.body.map { removeFoldUnfolds(_, prePredIds, postPredIds) }
+    val predIds = prePredIds ++ postPredIds
+    val rewrittenBody = method.body.map(removeFoldUnfolds(_, predIds))
     method.copy(body = rewrittenBody,
       pres = rewrittenPres,
       posts = rewrittenPosts,
@@ -100,18 +101,17 @@ trait InlineRewrite {
     * Removes given predicate unfolds and folds from statement.
     *
     * @param stmts A Seqn whose statements will be traversed
-    * @param unfoldPreds A set of the string names of the precondition predicates to not unfold
-    * @param foldPreds A set of the string names of the postcondition predicates to not fold
+    * @param predIds The list of predicates for which we want to remove fold/unfold pairs for
     * @return The Seqn with all above unfolds and folds removed
     */
-  private[this] def removeFoldUnfolds(stmts: Seqn, unfoldPreds: Set[String], foldPreds: Set[String]): Seqn = {
+  private[this] def removeFoldUnfolds(stmts: Seqn, predIds: Set[String]): Seqn = {
     ViperStrategy.Slim({
-      case seqn@Seqn(ss, scopedDecls) =>
-        seqn.copy(ss = ss.filter {
+      case seqn@Seqn(ss, _) =>
+        seqn.copy(ss = ss.filterNot {
           // TODO: Do we always remove folds/unfolds regardless of permission value?
-          case Fold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => !foldPreds(name)
-          case Unfold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => !unfoldPreds(name)
-          case _ => true
+          case Fold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => predIds(name)
+          case Unfold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => predIds(name)
+          case _ => false
         })(seqn.pos, seqn.info, seqn.errT)
     }, Traverse.BottomUp).execute[Seqn](stmts)
   }


### PR DESCRIPTION
I made some quick changes to the plugin in case Alan wants a demo. Running viper with the plugin should now print something like
```
============ INPUT PROGRAM ============
field left: Int

field right: Int

predicate allowAccess(this: Ref) {
  acc(this.left, write) && acc(this.right, write)
}

method makeTuple(this: Ref, i: Int, j: Int)
  requires acc(allowAccess(this), write)
{
  unfold acc(allowAccess(this), write)
  this.left := this.left + i
  this.right := this.right + j
  fold acc(allowAccess(this), write)
}
========== END INPUT PROGRAM ==========
========== REWRITTEN PROGRAM ==========
field left: Int

field right: Int

predicate allowAccess(this: Ref) {
  acc(this.left, write) && acc(this.right, write)
}

method makeTuple(this: Ref, i: Int, j: Int)
  requires acc(this.left, write) && acc(this.right, write)
{
  this.left := this.left + i
  this.right := this.right + j
  fold acc(allowAccess(this), write)
}
======== END REWRITTEN PROGRAM ========
```

I think that should be a good enough demo. 

## Steps

1. Clone `silicon` + have it [set up](https://github.com/jyoo980/silver/wiki/Setting-up-a-Development-Environment)
2. Run viper on the files `demo/tuple.vpr` or `demo/sum.vpr` to make stuff print to the console.