### PR TITLE
fixing issue where fold statements were not removed

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -32,14 +32,14 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
       // TODO: Do we also need to inline in inhale/exhale/assert/assume and package/apply statements?
       val (prePredIds, postPredIds) = getPrePostPredIds(method, input, inlinePredIds)
       val inlinedPredMethod = inlinePredicates(method, input, prePredIds, postPredIds)
-      rewriteMethod(inlinedPredMethod, input, prePredIds, postPredIds)
+      rewriteMethod(inlinedPredMethod, prePredIds, postPredIds)
     }
     // TODO: Do we also need to rewrite functions?
     ViperStrategy.Slim({
-      case program@Program(_, _, _, predicates, methods, extensions) =>
+      case program@Program(_, _, _, predicates, _, extensions) =>
         program.copy(
           methods = rewrittenMethods,
-          predicates = predicates ++ extensions.collect{case InlinePredicate(p) => p},  
+          predicates = predicates ++ extensions.collect{case InlinePredicate(p) => p},
         )(program.pos, program.info, program.errT)
     }).execute[Program](input)
   }


### PR DESCRIPTION
Previously, the complementary `fold` statement in the body was not removed when its corresponding `unfold` statement was removed. 

This is probably a naive way of fixing it (I think), and we'll probably have to look into it more later. 

Tested with the following
```
// tuple.vpr
field left: Int
field right: Int

predicate allowAccess(this: Ref)
{
	acc(this.left) && acc(this.right)
}

method makeTuple(this: Ref, i: Int, j: Int)
	requires allowAccess(this)
{
	unfold allowAccess(this)
	this.left := this.left + i
	this.right := this.right + j
	fold allowAccess(this)
}
```
```
// sum.vpr
predicate nonZero(k: Int)
{
  0 <= k
}


method sum(n: Int) returns (res: Int)
  requires nonZero(n) 
  ensures  res == n * (n + 1) / 2
{
  unfold nonZero(n)
  res := 0
  var i: Int := 0;
  while(i <= n)
    invariant i <= (n + 1)
    invariant res == (i - 1) * i / 2
  {
    res := res + i
    i := i + 1
  }
  fold nonZero(n)
}

```