### PR TITLE
adding initial implementation of permission passthrough

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -3,10 +3,9 @@ package viper.silver.plugin.standard.inline
 import scala.collection.mutable
 import viper.silver.ast._
 import viper.silver.ast.utility.ViperStrategy
-import viper.silver.ast.utility.rewriter.Traverse
-import viper.silver.ast.utility.rewriter.StrategyBuilder
+import viper.silver.ast.utility.rewriter.{StrategyBuilder, Traverse}
 
-trait InlineRewrite {
+trait InlineRewrite extends PredicateExpansion {
 
   def getPrePostPredIds(method: Method, program: Program, inlinePredIds: Set[String]): (Set[String], Set[String]) = {
     val expandablePrePredIds = method.pres.flatMap(expandablePredicates(_, method, program, inlinePredIds)).toSet
@@ -70,10 +69,11 @@ trait InlineRewrite {
     */
   private[this] def expandPredicates(expr: Exp, method: Method, program: Program, preds: Set[String]): Exp = {
     ViperStrategy.Context[Set[String]]({
-      case exp@(PredicateAccessPredicate(pred, _), ctxt) =>
+      case exp@(PredicateAccessPredicate(pred, perm), ctxt) =>
         val isInUnfolding = ctxt.parentOption.exists({_.isInstanceOf[Unfolding]})
         if (preds(pred.predicateName) && !isInUnfolding) {
-          (pred.predicateBody(program, ctxt.c).get, ctxt)
+          val maybePredBody = pred.predicateBody(program, ctxt.c)
+          (propagatePermission(maybePredBody, perm).get, ctxt)
         } else exp
       case (quant: QuantifiedExp, ctxt) =>
         (quant, ctxt.updateContext(ctxt.c ++ quant.scopedDecls.map { _.name }.toSet))

--- a/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
@@ -12,7 +12,7 @@ trait PredicateExpansion {
     *
     * @param maybeBody the body of a given predicate for which we want to thread the original permission value for.
     * @param originalPerm the original permission value used before inlining occurs.
-    * @return the predicate body after threading the orignal permission value, if defined. Otherwise
+    * @return the predicate body after threading the original permission value, if defined. Otherwise
     *         evaluate to None.
     */
   def propagatePermission(maybeBody: Option[Exp], originalPerm: Exp): Option[Exp] =

--- a/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
@@ -6,6 +6,15 @@ import viper.silver.ast.utility.rewriter.Traverse
 
 trait PredicateExpansion {
 
+  /**
+    * Given the body of a predicate, find any access statements and thread the original permission value
+    * into it. If the body is a None, evaluate to a None.
+    *
+    * @param maybeBody the body of a given predicate for which we want to thread the original permission value for.
+    * @param originalPerm the original permission value used before inlining occurs.
+    * @return the predicate body after threading the orignal permission value, if defined. Otherwise
+    *         evaluate to None.
+    */
   def propagatePermission(maybeBody: Option[Exp], originalPerm: Exp): Option[Exp] =
     maybeBody.map { body =>
       ViperStrategy.Slim({

--- a/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
@@ -1,0 +1,24 @@
+package viper.silver.plugin.standard.inline
+
+import viper.silver.ast.utility.ViperStrategy
+import viper.silver.ast.{Exp, FieldAccessPredicate, PredicateAccessPredicate}
+import viper.silver.ast.utility.rewriter.Traverse
+
+trait PredicateExpansion {
+
+  def propagatePermission(maybeBody: Option[Exp], originalPerm: Exp): Option[Exp] =
+    maybeBody.map { body =>
+      ViperStrategy.Slim({
+        case predAccessPred: PredicateAccessPredicate =>
+          predAccessPred.copy(
+            loc = predAccessPred.loc,
+            perm = originalPerm
+          )(pos = predAccessPred.pos, info = predAccessPred.info, errT = predAccessPred.errT)
+        case fieldAccessPred: FieldAccessPredicate =>
+          fieldAccessPred.copy(
+            loc = fieldAccessPred.loc,
+            perm = originalPerm
+          )(pos = fieldAccessPred.pos, info = fieldAccessPred.info, errT = fieldAccessPred.errT)
+      }, Traverse.TopDown).execute[Exp](body)
+    }
+}

--- a/src/test/scala/plugin/inline/PredicateExpansionTest.scala
+++ b/src/test/scala/plugin/inline/PredicateExpansionTest.scala
@@ -1,0 +1,49 @@
+package plugin.inline
+
+import org.scalatest.FunSuite
+import viper.silver.ast._
+import viper.silver.plugin.standard.inline.PredicateExpansion
+
+class PredicateExpansionTest extends FunSuite with PredicateExpansion {
+
+  test("propagatePermission should evaluate to None if the body of the predicate is None") {
+    val maybePredBody = None
+    val perm = FullPerm()()
+
+    propagatePermission(maybePredBody, perm).isEmpty
+  }
+
+  test("propagatePermission should propagate a fractional permission to one access") {
+    // Something like: acc(x.f, write), replace with acc(this.left, 1/2)
+    val fieldAccess = FieldAccessPredicate(
+      FieldAccess(LocalVar("x", Ref)(),Field("f",Int)(NoPosition))(NoPosition), FullPerm()(NoPosition)
+    )(NoPosition)
+    val maybePredBody = Some(fieldAccess)
+    val permToChangeTo = FractionalPerm(IntLit(1)(), IntLit(2)())()
+
+    propagatePermission(maybePredBody, permToChangeTo).exists {
+      case FieldAccessPredicate(_, changedPerm) => changedPerm == permToChangeTo
+      case _ => false
+    }
+  }
+
+  test("propagatePermission should propagate a fractional permission to more than one access") {
+    // Something like: acc(x.left, write) && acc(x.right, write)
+    val leftAccess = FieldAccessPredicate(
+      FieldAccess(LocalVar("x", Ref)(),Field("left",Int)(NoPosition))(NoPosition), FullPerm()(NoPosition)
+    )(NoPosition)
+    val rightAccess = FieldAccessPredicate(
+      FieldAccess(LocalVar("x", Ref)(),Field("right",Int)(NoPosition))(NoPosition), FullPerm()(NoPosition)
+    )(NoPosition)
+    val maybePredBody = Some(And(leftAccess, rightAccess)())
+    val permToChangeTo = FractionalPerm(IntLit(1)(), IntLit(2)())()
+
+    propagatePermission(maybePredBody, permToChangeTo).exists {
+      case FieldAccessPredicate(FieldAccess(LocalVar(_, _), Field("left", _)), changedPerm) =>
+        changedPerm == permToChangeTo
+      case FieldAccessPredicate(FieldAccess(LocalVar(_, _), Field("right", _)), changedPerm) =>
+        changedPerm == permToChangeTo
+      case _ => false
+    }
+  }
+}


### PR DESCRIPTION
Initial work for #9 

Unit tested + tested via CLI with
```js
field left: Int
field right: Int

predicate tuple(this: Ref)
{
    acc(this.left) && acc(this.right)
}

method addTuple(this: Ref)
  returns (sum: Int)
  requires acc(tuple(this), 1/2)
{
  unfold acc(tuple(this), 1/2)
  sum := this.left + this.right
}

```

expanding into

```js
field left: Int

field right: Int

predicate tuple(this: Ref) {
  acc(this.left, write) && acc(this.right, write)
}

method addTuple(this: Ref) returns (sum: Int)
  requires acc(this.left, 1 / 2) && acc(this.right, 1 / 2)
{
  sum := this.left + this.right
}
```