### PR TITLE
adding error detection for nested predicates

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -25,6 +25,61 @@ trait InlineErrorChecker {
   }
 
   /**
+    * For each predicate id, find its associated body in the program. If the predicate is nested,
+    * print a warning to the console that it shall not be inlined. Return a set of predicates that
+    * are recursive
+    *
+    * @param predicateIds the ids of the predicates we want to inline.
+    * @param program the program for which we are performing predicate inlining on.
+    * @return the set of nested predicates.
+    */
+  def checkNestedPreds(predicateIds: Set[String], program: Program): Set[Predicate] = {
+    val predicates = predicateIds.map(program.findPredicate)
+    val nestedPreds = predicates.filter {
+      case Predicate(name, _, _) => isNestedPred(name, predicates)
+    }
+    nestedPreds.foreach {
+      case Predicate(name, _, _) => println(s"Predicate: `$name` is a nested predicate. Will not be inlined")
+    }
+    nestedPreds
+  }
+
+  /**
+    * Given a predicate id and a list of other predicates, for every predicate in the list of other predicates,
+    * check if the predicate id exists within the predicate
+    *
+    * @param predId the id for the predicate we want to check for a nested definition.
+    * @param otherPredicates the list of predicates we want to search for predicate id in.
+    * @return true iff the predicate id is found to in any of the predicates in otherPredicates.
+    */
+  private[this] def isNestedPred(predId: String, otherPredicates: Set[Predicate]): Boolean = {
+    val filteredOtherPreds = otherPredicates.filterNot(_.name == predId)
+    val filteredOtherPredBodies = filteredOtherPreds.flatMap(_.body)
+    val nestedWithinFirst = filteredOtherPredBodies.exists {
+      case PredicateAccessPredicate(PredicateAccess(_, predName), _) => predName == predId
+      case _ => false
+    }
+    lazy val isInChildExpr = filteredOtherPredBodies.exists(findWithinExpr(predId, _))
+    nestedWithinFirst || isInChildExpr
+  }
+
+  /**
+    * Given a predicate id and an expression, check whether the predicate id is found within
+    * the expression or any of its child expressions.
+    *
+    * @param predId the id for the predicate we want to check for a nested definition.
+    * @param expr the expression which we want to check the existence of the predId
+    * @return true iff the expression or any of its children contains the id
+    */
+  private[this] def findWithinExpr(predId: String, expr: Node): Boolean =
+    if (expr.subnodes.isEmpty) false
+    else
+      expr match {
+        case PredicateAccessPredicate(PredicateAccess(_, otherPredName), _) => otherPredName == predId
+        case otherExpr => otherExpr.subnodes.exists(findWithinExpr(predId, _))
+      }
+
+  /**
     * Given a predicate id and possibly its body, search the body for a node of type
     * PredicateAccessPredicate(...) with the name identical to the predicate id.
     * If such a node is found, the predicate is recursively defined.

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -6,7 +6,6 @@ import viper.silver.ast.Program
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 import viper.silver.parser.ParserExtension
 import viper.silver.parser.FastParser._
-import viper.silver.parser._
 import White._
 
 class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
@@ -28,6 +27,7 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
   override def beforeVerify(input: Program): Program = {
     val rewrittenMethods = input.methods.map { method =>
       val inlinePredIds = input.extensions.collect({case InlinePredicate(p) => p.name}).toSet
+      checkNestedPreds(inlinePredIds, input)
       val recursivePreds = checkRecursive(inlinePredIds, input)
       // TODO: Do we also need to inline in inhale/exhale/assert/assume and package/apply statements?
       val (prePredIds, postPredIds) = getPrePostPredIds(method, input, inlinePredIds)


### PR DESCRIPTION
Tested with
```js
field left: Int
field right: Int
field middle: Int
field elem: Int
field next: Ref

predicate list(this: Ref) 
{
  acc(this.elem) && acc(this.next) &&
		(this.next != null ==> list(this.next))
}

predicate deep(this: Ref)
{
  acc(this.middle, write) && list(this)
}


predicate mid(this: Ref) {
  acc(this.middle, write) && deep(this)
}

predicate triple(this: Ref) {
  acc(this.left) && acc(this.right) && acc(this.right) && 
  acc(this.left) && acc(this.right) && acc(this.right) &&
  acc(this.left) && acc(this.right) && acc(this.right) &&
  acc(this.left) && acc(this.right) && mid(this)
}
```
result
```
jyoo@lambda silicon % ./silicon.sh --z3Exe '/Users/jyoo/dev/oss/z3/build/z3'  ~/Desktop/viper-tests/nested.vpr
Silicon 1.1-SNAPSHOT (f52b14f8+)
Predicate: `list` is recursive. Will not be inlined
Predicate: `mid` is a nested predicate. Will not be inlined
Predicate: `deep` is a nested predicate. Will not be inlined
Predicate: `list` is a nested predicate. Will not be inlined
successfully returned
Silicon finished verification successfully in 3.68s.
```
should resolve #20