### PR TITLE
Expand nested predicates

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -32,14 +32,14 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
       // TODO: Do we also need to inline in inhale/exhale/assert/assume and package/apply statements?
       val (prePredIds, postPredIds) = getPrePostPredIds(method, input, inlinePredIds)
       val inlinedPredMethod = inlinePredicates(method, input, prePredIds, postPredIds)
-      rewriteMethod(inlinedPredMethod, input, prePredIds, postPredIds)
+      rewriteMethod(inlinedPredMethod, prePredIds, postPredIds)
     }
     // TODO: Do we also need to rewrite functions?
     ViperStrategy.Slim({
-      case program@Program(_, _, _, predicates, methods, extensions) =>
+      case program@Program(_, _, _, predicates, _, extensions) =>
         program.copy(
           methods = rewrittenMethods,
-          predicates = predicates ++ extensions.collect{case InlinePredicate(p) => p},  
+          predicates = predicates ++ extensions.collect{case InlinePredicate(p) => p},
         )(program.pos, program.info, program.errT)
     }).execute[Program](input)
   }

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -27,20 +27,18 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
 
   override def beforeVerify(input: Program): Program = {
     val rewrittenMethods = input.methods.map { method =>
-      val allPredIds = input.predicates.filter(_.body.isDefined).map(_.name).toSet
+      val allPredIds = input.predicates.collect{ case p if p.body.isDefined => p.name }.toSet
       val recursivePredIds = (checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)).map(_.name)
       val nonrecursivePredIds = allPredIds.diff(recursivePredIds)
       val cond = { pred: String => nonrecursivePredIds(pred) }
-      // val inlinePredIds = input.extensions
-      //   .collect({case InlinePredicate(p) => p})
-      //   .filter(_.body.isDefined)
-      //   .map(_.name).toSet
+      // val inlinePredIds = input.extensions.collect({
+      //   case InlinePredicate(p) if p.body.isDefined => p.name
+      // }).toSet
       // val nonrecursiveInlinePredIds = inlinePredIds.diff(recursivePredIds)
       // val cond = { pred: String => nonrecursiveInlinePredIds(pred) }
       val inlinedPredMethod = inlinePredicates(method, input, cond)
       rewriteMethod(inlinedPredMethod, cond)
     }
-    // TODO: Do we also need to rewrite functions?
     ViperStrategy.Slim({
       case program@Program(_, _, _, predicates, _, extensions) =>
         program.copy(

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -3,60 +3,27 @@ package viper.silver.plugin.standard.inline
 import scala.collection.mutable
 import viper.silver.ast._
 import viper.silver.ast.utility.ViperStrategy
-import viper.silver.ast.utility.rewriter.{StrategyBuilder, Traverse}
+import viper.silver.ast.utility.rewriter.Traverse
 
 trait InlineRewrite extends PredicateExpansion {
 
-  def getPrePostPredIds(method: Method, program: Program, inlinePredIds: Set[String]): (Set[String], Set[String]) = {
-    val expandablePrePredIds = method.pres.flatMap(expandablePredicates(_, method, program, inlinePredIds)).toSet
-    val expandablePostPredsIds = method.posts.flatMap(expandablePredicates(_, method, program, inlinePredIds)).toSet
-    (expandablePrePredIds, expandablePostPredsIds)
-  }
-
-  def inlinePredicates(method: Method, program: Program, prePredIds: Set[String], postPredIds: Set[String]): Method = {
-    val expandedPres = method.pres.map { expandPredicates(_, method, program, prePredIds) }
-    val expandedPosts = method.posts.map { expandPredicates(_, method, program, postPredIds) }
+  def inlinePredicates(method: Method, program: Program, cond: String => Boolean): Method = {
+    val expandedPres = method.pres.map(expandPredicates(_, method, program, cond))
+    val expandedPosts = method.posts.map(expandPredicates(_, method, program, cond))
     method.copy(
       pres = expandedPres,
       posts = expandedPosts
     )(method.pos, method.info, method.errT)
   }
 
-  def rewriteMethod(method: Method, prePredIds: Set[String], postPredIds: Set[String]): Method = {
-    val rewrittenPres = method.pres.map { removeUnfoldings(_, prePredIds) }
-    val rewrittenPosts = method.posts.map { removeUnfoldings(_, postPredIds) }
-    val allPredIds = prePredIds ++ postPredIds
-    val rewrittenBody = method.body.map(removeFoldUnfolds(_, allPredIds))
+  def rewriteMethod(method: Method, cond: String => Boolean): Method = {
+    val rewrittenPres = method.pres.map { removeUnfoldings(_, cond) }
+    val rewrittenPosts = method.posts.map { removeUnfoldings(_, cond) }
+    val rewrittenBody = method.body.map { removeFoldUnfolds(_, cond) }
     method.copy(body = rewrittenBody,
       pres = rewrittenPres,
       posts = rewrittenPosts,
     )(method.pos, method.info, method.errT)
-  }
-
-  /**
-    * Returns a set of the names of the predicates that can be expanded into their bodies.
-    *
-    * @param expr The expression to check for predicates
-    * @param method The method containing the expression, used to determine locally-scoped variables
-    * @param program The program containing the expression, used to get predicate bodies
-    * @return A set of the names of the expandable predicates
-    */
-  private[this] def expandablePredicates(expr: Exp, method: Method, program: Program, inlinePredIds: Set[String]): Set[String] = {
-    // Forgive me deities of functional programming for I sin
-    val expandablePredicates = mutable.Set[String]()
-    StrategyBuilder.ContextVisitor[Node, Set[String]]({
-      // TODO: Do we need to keep track of the permission value?
-      case exp@(PredicateAccessPredicate(pred, _), ctxt) =>
-        // TODO: Always check inlinePredIds(pred.predicateName)?
-        if (pred.predicateBody(program, ctxt.c).isDefined) {
-          expandablePredicates += pred.predicateName
-        }
-        ctxt
-      case (quant: QuantifiedExp, ctxt) =>
-        ctxt.updateContext(ctxt.c ++ quant.scopedDecls.map { _.name }.toSet)
-      case (_, ctxt) => ctxt
-    }, method.scopedDecls.map { _.name }.toSet).execute[Exp](expr)
-    expandablePredicates.toSet
   }
 
   /**
@@ -65,20 +32,22 @@ trait InlineRewrite extends PredicateExpansion {
     * @param expr The expression whose predicates will be expanded
     * @param method The method containing the expression, used to determine locally-scoped variables
     * @param program The program containing the expression, used to expand predicates
-    * @param preds The predicates that we are allowed to expand
-    * @return The expression with expanded predicates
+    * @param cond The predicate (Scala) that the predicates (Viper) must satisfy
+    * @return The expression with expanded predicates and the expandable precondition and postcondition predicates
     */
-  private[this] def expandPredicates(expr: Exp, method: Method, program: Program, preds: Set[String]): Exp = {
+  private[this] def expandPredicates(expr: Exp, method: Method, program: Program, cond: String => Boolean): Exp = {
+    val expandablePredicates = mutable.Set[String]()
     ViperStrategy.Context[Set[String]]({
       case exp@(PredicateAccessPredicate(pred, perm), ctxt) =>
-        val isInUnfolding = ctxt.parentOption.exists({_.isInstanceOf[Unfolding]})
-        if (preds(pred.predicateName) && !isInUnfolding) {
-          val maybePredBody = pred.predicateBody(program, ctxt.c)
-          (propagatePermission(maybePredBody, perm).get, ctxt)
+        val isInUnfolding = ctxt.parentOption.exists(_.isInstanceOf[Unfolding])
+        if (cond(pred.predicateName) && !isInUnfolding) {
+          expandablePredicates += pred.predicateName
+          val optPredBody = pred.predicateBody(program, ctxt.c)
+          (propagatePermission(optPredBody, perm).get, ctxt)
         } else exp
-      case (quant: QuantifiedExp, ctxt) =>
-        (quant, ctxt.updateContext(ctxt.c ++ quant.scopedDecls.map { _.name }.toSet))
-    }, method.scopedDecls.map { _.name }.toSet, Traverse.TopDown)
+      case (scope: Scope, ctxt) =>
+        (scope, ctxt.updateContext(ctxt.c ++ scope.scopedDecls.map(_.name).toSet))
+    }, method.scopedDecls.map(_.name).toSet, Traverse.TopDown)
       .execute[Exp](expr)
   }
 
@@ -86,14 +55,13 @@ trait InlineRewrite extends PredicateExpansion {
     * Replaces unfolding expressions by their bodies if the unfolded predicate had been expanded
     *
     * @param expr The expression whose unfoldings may be substituted
-    * @param preds A set of the string names of the predicates that have been expanded
+    * @param cond The condition a predicate must satisfy to be un-unfolding-ed
     * @return The expression with unfoldings possibly substituted
     */
-  private[this] def removeUnfoldings(expr: Exp, preds: Set[String]): Exp = {
+  private[this] def removeUnfoldings(expr: Exp, cond: String => Boolean): Exp = {
     ViperStrategy.Slim({
-      // TODO: Do we always remove unfoldings regardless of permission value?
       case unfolding@Unfolding(PredicateAccessPredicate(PredicateAccess(_, name), _), body) =>
-        if (preds(name)) body else unfolding
+        if (cond(name)) body else unfolding
     }, Traverse.BottomUp).execute[Exp](expr)
   }
 
@@ -101,16 +69,15 @@ trait InlineRewrite extends PredicateExpansion {
     * Removes given predicate unfolds and folds from statement.
     *
     * @param stmts A Seqn whose statements will be traversed
-    * @param predIds The set of predicates for which we will remove unfold and fold statements
+    * @param cond The condition a predicate must satisfy to no longer require (un)folding
     * @return The Seqn with all above unfolds and folds removed
     */
-  private[this] def removeFoldUnfolds(stmts: Seqn, predIds: Set[String]): Seqn = {
+  private[this] def removeFoldUnfolds(stmts: Seqn, cond: String => Boolean): Seqn = {
     ViperStrategy.Slim({
       case seqn@Seqn(ss, _) =>
         seqn.copy(ss = ss.filterNot {
-          // TODO: Do we always remove folds/unfolds regardless of permission value?
-          case Fold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => predIds(name)
-          case Unfold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => predIds(name)
+          case Fold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => cond(name)
+          case Unfold(PredicateAccessPredicate(PredicateAccess(_, name), _)) => cond(name)
           case _ => false
         })(seqn.pos, seqn.info, seqn.errT)
     }, Traverse.BottomUp).execute[Seqn](stmts)


### PR DESCRIPTION
Fixes #20.

At first I had merged getting the predicate ids with expanding the predicates because it's really tricky getting all those nested names without doing the actual expansion, but since we only don't expand (mutually) recursive predicates, we don't need to return those names anyway.

Also, instead of passing in a set of predicate names that are or aren't expanded, I've abstracted that into a condition that's passed along (a Scala predicate for the Viper predicate names, so to speak) so that we can adjust the condition in `InlinePredicatePlugin` if ever needed.

Meanwhile, in `beforeVerify`, I've added getting *all* predicate ids in advance, filtered by whether those have bodies, since it's not really `expandPredicate`'s business to find out anyway; all it should do is check `cond`, check current scope, eat hot chip, and lie.

I've also commented out the stuff to do with the inline keyword. Once that's implemented, we can switch over, but I imagine we might also want to provide a global flag of some sort to say "please inline all predicates by default", then inline only those with the keyword in its absence? Then whether the cond uses `nonrecursivePredIds` or `nonrecursiveInlinePredIds` depends on the state of the flag. I suppose I should open a new stretch goal issue for that (but it could be as simple as adding a parser for a new type of declaration!).

Also it turns out I was working on the wrong branch so I've committed on top of a (fork of) [yoo/fix-fold-unfold-bug](/jyoo980/silver/tree/yoo/fix-fold-unfold-bug) oops, which I guess means this would also fix #10 if merged?