### PR TITLE
Implemented expanding asserts and invariants.

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -44,14 +44,15 @@ trait InlineRewrite extends PredicateExpansion {
   }
 
   /**
-    * Given an inhale, exhale, or assert statement, look within it for any predicate accesses.
+    * Given an inhale, exhale, or assert statement, or a while loop invariant,
+    * look within it for any predicate accesses.
     * If found, return the same statement with the expanded body of the predicate.
     *
     * @param stmts A Seqn whose statements will be traversed.
     * @param method The method containing the inhale statement we wish to expand.
     * @param program The Viper program for which we perform this expansion.
     * @param cond The condition a predicate must satisfy to be expanded within an inhale statement.
-    * @return The Seqn with all inhale, exhale, and assert statements expanded.
+    * @return The Seqn with all inhale, exhale, assert, and while loop statements expanded.
     */
   private[this] def expandStatements(stmts: Seqn, method: Method, program: Program, cond: String => Boolean): Seqn =
     ViperStrategy.Slim({

--- a/vpr-test-files/assert-invariant.vpr
+++ b/vpr-test-files/assert-invariant.vpr
@@ -1,0 +1,32 @@
+field left: Int
+field middle: Int
+field right: Int
+
+predicate triple(this: Ref) {
+  acc(this.left) && acc(this.right) && mid(this)
+}
+
+predicate mid(this: Ref) {
+  acc(this.middle)
+}
+
+method tripleSum(this: Ref)
+  returns  (sum: Int)
+  requires triple(this)
+  ensures  triple(this)
+  ensures  unfolding triple(this) in unfolding mid(this) in sum == this.left + this.middle + this.right
+{
+  assert unfolding triple(this) in unfolding mid(this) in this.left == this.left
+  while (true)
+    invariant triple(this)
+  {
+    inhale triple(this)
+    exhale triple(this)
+  }
+
+  unfold triple(this)
+  unfold mid(this)
+  sum := this.left + this.middle + this.right
+  fold mid(this)
+  fold triple(this)
+}


### PR DESCRIPTION
For #15, implement expanding `assert` and `invariant` because we might as well.

This also calls `removeUnfolding` in the (newly renamed) `expandExpression`, since every time we expand an expression we do actually want to remove unfoldings anyway. This also has the benefit that we don't need to do sneaky checks to see if the current `PredicateAccessPredicate` occurs inside of an `Unfolding`.

As mentioned, `expandPredicates` has been renamed to `expandExpression` to mirror `expandStatements`, formerly `expandInhaleExhale`, renamed because it now handles `assert` and `invariant`.

I was thinking about combining `inlinePredicates` and `rewriteMethod` but expanding exps and stmts is kind of different from outright removing stmts, I guess.