### PR TITLE
adding potential fix for preds called by recursive preds

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -44,28 +44,6 @@ trait InlineErrorChecker {
   }
 
   /**
-    * Given a predicate, evaluate to a set containing the names of all predicates called by it.
-    * Only return the names of predicates called that aren't equal to itself.
-    *
-    * @param pred the predicate we want to collect the names of inner predicate calls for.
-    * @return a set of the ids of predicates called in the given predicate.
-    */
-  def nonRecursivePredsCalledBy(pred: Predicate): Option[Set[String]] =
-    pred.body.map { body =>
-      val children = body.subnodes
-      // Forgive me Father Alonzo for I have Sinned
-      var calledPreds = Set[String]()
-      children.foreach { child =>
-        child.visit {
-          case PredicateAccessPredicate(calledPred, _) =>
-            if (calledPred.predicateName != pred.name)
-              calledPreds += calledPred.predicateName
-        }
-      }
-      calledPreds
-    }
-
-  /**
     * Given a predicate id and possibly its body, search the body for a node of type
     * PredicateAccessPredicate(...) with the name identical to the predicate id.
     * If such a node is found, the predicate is recursively defined.

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -44,6 +44,28 @@ trait InlineErrorChecker {
   }
 
   /**
+    * Given a predicate, evaluate to a set containing the names of all predicates called by it.
+    * Only return the names of predicates called that aren't equal to itself.
+    *
+    * @param pred the predicate we want to collect the names of inner predicate calls for.
+    * @return a set of the ids of predicates called in the given predicate.
+    */
+  def nonRecursivePredsCalledBy(pred: Predicate): Option[Set[String]] =
+    pred.body.map { body =>
+      val children = body.subnodes
+      // Forgive me Father Alonzo for I have Sinned
+      var calledPreds = Set[String]()
+      children.foreach { child =>
+        child.visit {
+          case PredicateAccessPredicate(calledPred, _) =>
+            if (calledPred.predicateName != pred.name)
+              calledPreds += calledPred.predicateName
+        }
+      }
+      calledPreds
+    }
+
+  /**
     * Given a predicate id and possibly its body, search the body for a node of type
     * PredicateAccessPredicate(...) with the name identical to the predicate id.
     * If such a node is found, the predicate is recursively defined.

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -29,7 +29,8 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
   override def beforeVerify(input: Program): Program = {
     val rewrittenMethods = input.methods.map { method =>
       val allPredIds = input.predicates.collect{ case p if p.body.nonEmpty => p.name }.toSet
-      val recursivePredIds = (checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)).map(_.name)
+      val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
+      val recursivePredIds = recursivePreds.map(_.name)
       val nonrecursivePredIds = allPredIds.diff(recursivePredIds)
       val cond = { pred: String => nonrecursivePredIds(pred) }
       // val inlinePredIds = input.extensions.collect({
@@ -38,7 +39,7 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
       // val nonrecursiveInlinePredIds = inlinePredIds.diff(recursivePredIds)
       // val cond = { pred: String => nonrecursiveInlinePredIds(pred) }
       val inlinedPredMethod = inlinePredicates(method, input, cond)
-      rewriteMethod(inlinedPredMethod, cond)
+      rewriteMethod(inlinedPredMethod, cond, recursivePreds)
     }
     ViperStrategy.Slim({
       case program@Program(_, _, _, predicates, _, extensions) =>

--- a/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
+++ b/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
@@ -98,35 +98,4 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val result = checkMutualRecursive(Set(firstPredId, secondPredId), program)
     result.size == 2 && result(firstPred) && result(secondPred)
   }
-
-  test("predicatesCalledBy should evaluate to None given a predicate with an empty body") {
-    val emptyPred = Predicate("empty", Seq(), body = None)()
-
-    nonRecursivePredsCalledBy(emptyPred).isEmpty
-  }
-
-  test("predicatesCalledBy should not return predicates names for recursive preds") {
-    val predId = "rec"
-    val maybeRecursiveBody = Some(PredicateAccessPredicate(PredicateAccess(Seq(), predId)(), FullPerm.apply()())())
-    val recursivePred = Predicate(predId, formalArgs = Seq(), body = maybeRecursiveBody)()
-
-    nonRecursivePredsCalledBy(recursivePred).isEmpty
-  }
-
-  test("predicatesCalledBy should return predicates called in the body of the given predicate") {
-    val calledPredId = "F"
-    val recursivePredId = "loop"
-    val maybeRecursiveBody = Some(
-      And(
-        PredicateAccessPredicate(PredicateAccess(Seq(), recursivePredId)(), FullPerm.apply()())(),
-        PredicateAccessPredicate(PredicateAccess(Seq(), calledPredId)(), FullPerm.apply()())(),
-      )()
-    )
-    val pred = Predicate("loop", formalArgs = Seq(), body = maybeRecursiveBody)()
-
-    val maybeResult = nonRecursivePredsCalledBy(pred)
-    maybeResult.fold(false) { result =>
-      result.size == 1 && result(calledPredId)
-    }
-  }
 }

--- a/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
+++ b/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
@@ -98,4 +98,35 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val result = checkMutualRecursive(Set(firstPredId, secondPredId), program)
     result.size == 2 && result(firstPred) && result(secondPred)
   }
+
+  test("predicatesCalledBy should evaluate to None given a predicate with an empty body") {
+    val emptyPred = Predicate("empty", Seq(), body = None)()
+
+    nonRecursivePredsCalledBy(emptyPred).isEmpty
+  }
+
+  test("predicatesCalledBy should not return predicates names for recursive preds") {
+    val predId = "rec"
+    val maybeRecursiveBody = Some(PredicateAccessPredicate(PredicateAccess(Seq(), predId)(), FullPerm.apply()())())
+    val recursivePred = Predicate(predId, formalArgs = Seq(), body = maybeRecursiveBody)()
+
+    nonRecursivePredsCalledBy(recursivePred).isEmpty
+  }
+
+  test("predicatesCalledBy should return predicates called in the body of the given predicate") {
+    val calledPredId = "F"
+    val recursivePredId = "loop"
+    val maybeRecursiveBody = Some(
+      And(
+        PredicateAccessPredicate(PredicateAccess(Seq(), recursivePredId)(), FullPerm.apply()())(),
+        PredicateAccessPredicate(PredicateAccess(Seq(), calledPredId)(), FullPerm.apply()())(),
+      )()
+    )
+    val pred = Predicate("loop", formalArgs = Seq(), body = maybeRecursiveBody)()
+
+    val maybeResult = nonRecursivePredsCalledBy(pred)
+    maybeResult.fold(false) { result =>
+      result.size == 1 && result(calledPredId)
+    }
+  }
 }

--- a/vpr-test-files/minimal.vpr
+++ b/vpr-test-files/minimal.vpr
@@ -1,0 +1,17 @@
+field f: Int
+
+predicate F(this: Ref) {
+  acc(this.f)
+}
+
+predicate loop(this: Ref) {
+  loop(this) && F(this)
+}
+
+method nestedPred(this: Ref)
+  requires loop(this)
+{
+  unfold loop(this)
+  unfold F(this)
+  this.f := 0
+}


### PR DESCRIPTION
See #34 for more

I'm not exactly confident with this fix, so a more stringent review would be appreciated.

Works for the minimal example that @ionathanch  provided, but on [`AVLTree.iterative.vpr`](https://github.com/jyoo980/silver/blob/master/src/test/resources/all/chalice/AVLTree.iterative.vpr), we still get an error (a different one downstream)