### PR TITLE
adding potential fix for nested non-recursive pred calls in recursive preds

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -52,10 +52,9 @@ trait InlineErrorChecker {
     */
   def nonRecursivePredsCalledBy(pred: Predicate): Option[Set[String]] =
     pred.body.map { body =>
-      val children = body.subnodes
       // Forgive me Father Alonzo for I have Sinned
       var calledPreds = Set[String]()
-      children.foreach { child =>
+      body.foreach { child =>
         child.visit {
           case PredicateAccessPredicate(calledPred, _) =>
             if (calledPred.predicateName != pred.name)

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -50,18 +50,18 @@ trait InlineErrorChecker {
     * @param pred the predicate we want to collect the names of inner predicate calls for.
     * @return a set of the ids of predicates called in the given predicate.
     */
-  def nonRecursivePredsCalledBy(pred: Predicate, program: Program): Option[Set[String]] =
+  def nonRecursivePredsCalledBy(pred: Predicate, program: Program, recursivePredNames: Set[String]): Option[Set[String]] =
     pred.body.map { body =>
       // Forgive me Father Alonzo for I have Sinned
       var calledPreds = Set[String]()
       body.foreach { child =>
         child.visit {
           case PredicateAccessPredicate(calledPredAcc, _) =>
-            if (calledPredAcc.predicateName != pred.name) {
+            if (calledPredAcc.predicateName != pred.name && !recursivePredNames(calledPredAcc.predicateName)) {
               val calledPredLiteral = program.findPredicate(calledPredAcc.predicateName)
               calledPreds += calledPredAcc.predicateName
               // I don't like using .getOrElse but it's type-safe in this case
-              calledPreds ++= nonRecursivePredsCalledBy(calledPredLiteral, program).getOrElse(Set[String]())
+              calledPreds ++= nonRecursivePredsCalledBy(calledPredLiteral, program, recursivePredNames).getOrElse(Set[String]())
             }
         }
       }

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -62,7 +62,6 @@ trait InlineErrorChecker {
             if (!recursivePredIds(calledPredAcc.predicateName)) {
               val calledPredLiteral = program.findPredicate(calledPredAcc.predicateName)
               calledPredIds += calledPredAcc.predicateName
-              // I don't like using .getOrElse but it's type-safe in this case
               calledPredIds ++= nonRecursivePredsCalledBy(calledPredLiteral, recursivePredIds, program)
             }
         }

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -57,7 +57,7 @@ trait InlineErrorChecker {
       body.foreach { child =>
         child.visit {
           case PredicateAccessPredicate(calledPredAcc, _) =>
-            if (calledPredAcc.predicateName != pred.name && !recursivePredNames(calledPredAcc.predicateName)) {
+            if (!recursivePredNames(calledPredAcc.predicateName)) {
               val calledPredLiteral = program.findPredicate(calledPredAcc.predicateName)
               calledPreds += calledPredAcc.predicateName
               // I don't like using .getOrElse but it's type-safe in this case

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineErrorChecker.scala
@@ -44,6 +44,28 @@ trait InlineErrorChecker {
   }
 
   /**
+    * Given a predicate, evaluate to a set containing the names of all predicates called by it.
+    * Only return the names of predicates called that aren't equal to itself.
+    *
+    * @param pred the predicate we want to collect the names of inner predicate calls for.
+    * @return a set of the ids of predicates called in the given predicate.
+    */
+  def nonRecursivePredsCalledBy(pred: Predicate): Option[Set[String]] =
+    pred.body.map { body =>
+      val children = body.subnodes
+      // Forgive me Father Alonzo for I have Sinned
+      var calledPreds = Set[String]()
+      children.foreach { child =>
+        child.visit {
+          case PredicateAccessPredicate(calledPred, _) =>
+            if (calledPred.predicateName != pred.name)
+              calledPreds += calledPred.predicateName
+        }
+      }
+      calledPreds
+    }
+
+  /**
     * Given a predicate id and possibly its body, search the body for a node of type
     * PredicateAccessPredicate(...) with the name identical to the predicate id.
     * If such a node is found, the predicate is recursively defined.

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -30,7 +30,7 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
     val allPredIds = input.predicates.collect{ case p if p.body.nonEmpty => p.name }.toSet
     val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
     val recursivePredIds = recursivePreds.map(_.name)
-    val predsIdsCalledByOtherPreds = allPredIds.map(input.findPredicate).flatMap(nonRecursivePredsCalledBy).flatten
+    val predsIdsCalledByOtherPreds = recursivePreds.flatMap(nonRecursivePredsCalledBy(_, input)).flatten
     val nonRecursivePredIds = allPredIds.diff(recursivePredIds)
     val cond = { pred: String => nonRecursivePredIds(pred) && !predsIdsCalledByOtherPreds(pred) }
     // val inlinePredIds = input.extensions.collect({

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -30,9 +30,8 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
     val allPredIds = input.predicates.collect{ case p if p.body.nonEmpty => p.name }.toSet
     val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
     val recursivePredIds = recursivePreds.map(_.name)
-    val predsIdsCalledByOtherPreds = recursivePreds.flatMap(nonRecursivePredsCalledBy(_, input, recursivePredIds)).flatten
-    val nonRecursivePredIds = allPredIds.diff(recursivePredIds)
-    val cond = { pred: String => nonRecursivePredIds(pred) && !predsIdsCalledByOtherPreds(pred) }
+    val predIdsCalledByRecursivePreds = recursivePreds.flatMap(nonRecursivePredsCalledBy(_, recursivePredIds, input))
+    val cond = { pred: String => !recursivePredIds(pred) && !predIdsCalledByRecursivePreds(pred) }
     // val inlinePredIds = input.extensions.collect({
     //   case InlinePredicate(p) if p.body.isDefined => p.name
     // }).toSet

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -30,7 +30,7 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
     val allPredIds = input.predicates.collect{ case p if p.body.nonEmpty => p.name }.toSet
     val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
     val recursivePredIds = recursivePreds.map(_.name)
-    val predsIdsCalledByOtherPreds = recursivePreds.flatMap(nonRecursivePredsCalledBy(_, input)).flatten
+    val predsIdsCalledByOtherPreds = recursivePreds.flatMap(nonRecursivePredsCalledBy(_, input, recursivePredIds)).flatten
     val nonRecursivePredIds = allPredIds.diff(recursivePredIds)
     val cond = { pred: String => nonRecursivePredIds(pred) && !predsIdsCalledByOtherPreds(pred) }
     // val inlinePredIds = input.extensions.collect({

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -28,9 +28,11 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
 
   override def beforeVerify(input: Program): Program = {
     val allPredIds = input.predicates.collect{ case p if p.body.nonEmpty => p.name }.toSet
-    val recursivePredIds = (checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)).map(_.name)
-    val nonrecursivePredIds = allPredIds.diff(recursivePredIds)
-    val cond = { pred: String => nonrecursivePredIds(pred) }
+    val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
+    val recursivePredIds = recursivePreds.map(_.name)
+    val calledByRecursivePredIds = recursivePreds.flatMap(nonRecursivePredsCalledBy).flatten
+    val nonRecursivePredIds = allPredIds.diff(recursivePredIds)
+    val cond = { pred: String => nonRecursivePredIds(pred) && !calledByRecursivePredIds(pred) }
     // val inlinePredIds = input.extensions.collect({
     //   case InlinePredicate(p) if p.body.isDefined => p.name
     // }).toSet

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -30,9 +30,10 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
     val allPredIds = input.predicates.collect{ case p if p.body.nonEmpty => p.name }.toSet
     val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
     val recursivePredIds = recursivePreds.map(_.name)
-    val calledByRecursivePredIds = recursivePreds.flatMap(nonRecursivePredsCalledBy).flatten
+    val predsIdsCalledByOtherPreds = allPredIds.map(input.findPredicate).flatMap(nonRecursivePredsCalledBy).flatten
+    println(s"$predsIdsCalledByOtherPreds")
     val nonRecursivePredIds = allPredIds.diff(recursivePredIds)
-    val cond = { pred: String => nonRecursivePredIds(pred) && !calledByRecursivePredIds(pred) }
+    val cond = { pred: String => nonRecursivePredIds(pred) && !predsIdsCalledByOtherPreds(pred) }
     // val inlinePredIds = input.extensions.collect({
     //   case InlinePredicate(p) if p.body.isDefined => p.name
     // }).toSet

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -31,7 +31,6 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
     val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
     val recursivePredIds = recursivePreds.map(_.name)
     val predsIdsCalledByOtherPreds = allPredIds.map(input.findPredicate).flatMap(nonRecursivePredsCalledBy).flatten
-    println(s"$predsIdsCalledByOtherPreds")
     val nonRecursivePredIds = allPredIds.diff(recursivePredIds)
     val cond = { pred: String => nonRecursivePredIds(pred) && !predsIdsCalledByOtherPreds(pred) }
     // val inlinePredIds = input.extensions.collect({

--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -4,7 +4,7 @@ import viper.silver.ast._
 import viper.silver.ast.utility.ViperStrategy
 import viper.silver.ast.utility.rewriter.Traverse
 
-trait InlineRewrite extends PredicateExpansion {
+trait InlineRewrite extends PredicateExpansion with InlineErrorChecker {
 
   def rewriteMethod(method: Method, program: Program, cond: String => Boolean): Method = {
     val expandedPres = method.pres.map(expandExpression(_, method, program, cond))

--- a/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
+++ b/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
@@ -103,7 +103,7 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val emptyPred = Predicate("empty", Seq(), body = None)()
     val program = programCopy()
 
-    nonRecursivePredsCalledBy(emptyPred, program).isEmpty
+    nonRecursivePredsCalledBy(emptyPred, program, Set()).isEmpty
   }
 
   test("predicatesCalledBy should not return predicates names for recursive preds") {
@@ -112,7 +112,7 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val recursivePred = Predicate(predId, formalArgs = Seq(), body = maybeRecursiveBody)()
     val program = programCopy()
 
-    nonRecursivePredsCalledBy(recursivePred, program).isEmpty
+    nonRecursivePredsCalledBy(recursivePred, program, Set("rec")).isEmpty
   }
 
   test("predicatesCalledBy should return predicates called in the body of the given predicate") {
@@ -128,7 +128,7 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val program = programCopy(predicates = Seq(predicateForF))
     val pred = Predicate("loop", formalArgs = Seq(), body = maybeRecursiveBody)()
 
-    val maybeResult = nonRecursivePredsCalledBy(pred, program)
+    val maybeResult = nonRecursivePredsCalledBy(pred, program, Set("loop"))
     maybeResult.fold(false) { result =>
       result.size == 1 && result(calledPredId)
     }
@@ -168,9 +168,9 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
       )
     )
 
-    val maybeResult = nonRecursivePredsCalledBy(loopPred, program)
+    val maybeResult = nonRecursivePredsCalledBy(loopPred, program, Set("loop"))
     maybeResult.fold(false) { result =>
-      result.size == 2 && Set(f, g).subsetOf(result)
+      result.size == 2 && Set(f, g) == result
     }
   }
 }

--- a/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
+++ b/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
@@ -103,7 +103,7 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val emptyPred = Predicate("empty", Seq(), body = None)()
     val program = programCopy()
 
-    nonRecursivePredsCalledBy(emptyPred, program, Set()).isEmpty
+    nonRecursivePredsCalledBy(emptyPred, Set(), program).isEmpty
   }
 
   test("predicatesCalledBy should not return predicates names for recursive preds") {
@@ -112,7 +112,7 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val recursivePred = Predicate(predId, formalArgs = Seq(), body = maybeRecursiveBody)()
     val program = programCopy()
 
-    nonRecursivePredsCalledBy(recursivePred, program, Set("rec")).isEmpty
+    nonRecursivePredsCalledBy(recursivePred, Set("rec"), program).isEmpty
   }
 
   test("predicatesCalledBy should return predicates called in the body of the given predicate") {
@@ -128,10 +128,8 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val program = programCopy(predicates = Seq(predicateForF))
     val pred = Predicate("loop", formalArgs = Seq(), body = maybeRecursiveBody)()
 
-    val maybeResult = nonRecursivePredsCalledBy(pred, program, Set("loop"))
-    maybeResult.fold(false) { result =>
-      result.size == 1 && result(calledPredId)
-    }
+    val result = nonRecursivePredsCalledBy(pred, Set("loop"), program)
+    result.size == 1 && result(calledPredId)
   }
 
   test("predicatesCalledBy should traverse subpredicates") {
@@ -168,9 +166,7 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
       )
     )
 
-    val maybeResult = nonRecursivePredsCalledBy(loopPred, program, Set("loop"))
-    maybeResult.fold(false) { result =>
-      result.size == 2 && Set(f, g) == result
-    }
+    val result = nonRecursivePredsCalledBy(loopPred, Set("loop"), program)
+    result.size == 2 && Set(f, g) == result
   }
 }

--- a/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
+++ b/src/test/scala/plugin/inline/InlineErrorCheckerTest.scala
@@ -98,4 +98,35 @@ class InlineErrorCheckerTest extends FunSuite with InlineErrorChecker with Inlin
     val result = checkMutualRecursive(Set(firstPredId, secondPredId), program)
     result.size == 2 && result(firstPred) && result(secondPred)
   }
+
+  test("predicatesCalledBy should evaluate to None given a predicate with an empty body") {
+    val emptyPred = Predicate("empty", Seq(), body = None)()
+
+    nonRecursivePredsCalledBy(emptyPred).isEmpty
+  }
+
+  test("predicatesCalledBy should not return predicates names for recursive preds") {
+    val predId = "rec"
+    val maybeRecursiveBody = Some(PredicateAccessPredicate(PredicateAccess(Seq(), predId)(), FullPerm.apply()())())
+    val recursivePred = Predicate(predId, formalArgs = Seq(), body = maybeRecursiveBody)()
+
+    nonRecursivePredsCalledBy(recursivePred).isEmpty
+  }
+
+  test("predicatesCalledBy should return predicates called in the body of the given predicate") {
+    val calledPredId = "F"
+    val recursivePredId = "loop"
+    val maybeRecursiveBody = Some(
+      And(
+        PredicateAccessPredicate(PredicateAccess(Seq(), recursivePredId)(), FullPerm.apply()())(),
+        PredicateAccessPredicate(PredicateAccess(Seq(), calledPredId)(), FullPerm.apply()())(),
+      )()
+    )
+    val pred = Predicate("loop", formalArgs = Seq(), body = maybeRecursiveBody)()
+
+    val maybeResult = nonRecursivePredsCalledBy(pred)
+    maybeResult.fold(false) { result =>
+      result.size == 1 && result(calledPredId)
+    }
+  }
 }

--- a/vpr-test-files/minimal.vpr
+++ b/vpr-test-files/minimal.vpr
@@ -1,0 +1,17 @@
+ field f: Int
+
+ predicate F(this: Ref) {
+   acc(this.f)
+ }
+
+ predicate loop(this: Ref) {
+   loop(this) && F(this)
+ }
+
+ method nestedPred(this: Ref)
+   requires loop(this)
+ {
+   unfold loop(this)
+   unfold F(this)
+   this.f := 0
+ }


### PR DESCRIPTION
See #34 for more

I'm not exactly confident with this fix, so a more stringent review would be appreciated.

Works for the minimal example that @ionathanch  provided, but on [`AVLTree.iterative.vpr`](https://github.com/jyoo980/silver/blob/master/src/test/resources/all/chalice/AVLTree.iterative.vpr), we still get an error (a different one downstream)

```
[0] Postcondition of has might not hold. There might be insufficient permission to access this.root1.root (avltree.iterative.vpr@7.6)
```