### PR TITLE
Fix incorrect permission propagation (should be multiplicative)

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/PredicateExpansion.scala
@@ -1,7 +1,7 @@
 package viper.silver.plugin.standard.inline
 
 import viper.silver.ast.utility.ViperStrategy
-import viper.silver.ast.{Exp, FieldAccessPredicate, PredicateAccessPredicate}
+import viper.silver.ast._
 import viper.silver.ast.utility.rewriter.Traverse
 
 trait PredicateExpansion {
@@ -17,17 +17,19 @@ trait PredicateExpansion {
     */
   def propagatePermission(maybeBody: Option[Exp], originalPerm: Exp): Option[Exp] =
     maybeBody.map { body =>
-      ViperStrategy.Slim({
-        case predAccessPred: PredicateAccessPredicate =>
-          predAccessPred.copy(
-            loc = predAccessPred.loc,
-            perm = originalPerm
-          )(pos = predAccessPred.pos, info = predAccessPred.info, errT = predAccessPred.errT)
-        case fieldAccessPred: FieldAccessPredicate =>
-          fieldAccessPred.copy(
-            loc = fieldAccessPred.loc,
-            perm = originalPerm
-          )(pos = fieldAccessPred.pos, info = fieldAccessPred.info, errT = fieldAccessPred.errT)
-      }, Traverse.TopDown).execute[Exp](body)
+      ViperStrategy.CustomContext[Exp]({
+        case (predAcc@PredicateAccessPredicate(_, perm), outerPerm) =>
+          val propagatedPerm = PermMul(perm, outerPerm)(perm.pos, perm.info, perm.errT)
+          val modifiedPredAcc = predAcc.copy(
+              perm = propagatedPerm
+            )(predAcc.pos, predAcc.info, predAcc.errT)
+          (modifiedPredAcc, propagatedPerm)
+        case (fieldAcc@FieldAccessPredicate(_, perm), outerPerm) =>
+          val propagatedPerm = PermMul(perm, outerPerm)(perm.pos, perm.info, perm.errT)
+          val modifiedFieldAcc = fieldAcc.copy(
+              perm = propagatedPerm
+            )(fieldAcc.pos, fieldAcc.info, fieldAcc.errT)
+          (modifiedFieldAcc, propagatedPerm)
+      }, originalPerm, Traverse.TopDown).execute[Exp](body)
     }
 }

--- a/vpr-test-files/permission-propagation.vpr
+++ b/vpr-test-files/permission-propagation.vpr
@@ -1,0 +1,12 @@
+field i: Int
+
+predicate int(this: Ref) {
+  acc(this.i, 1/2)
+}
+
+predicate intint(this: Ref) {
+  acc(this.i, 1/4) && acc(int(this), 1/5)
+}
+
+method test(this: Ref)
+  requires acc(intint(this), 1/3) {}


### PR DESCRIPTION
The permissions propagated down now accumulate multiplicatively. The committed test Viper file gets expanded into the following:

```javascript
field i: Int

predicate int(this: Ref) {
  acc(this.i, 1 / 2)
}

predicate intint(this: Ref) {
  acc(this.i, 1 / 4) && acc(int(this), 1 / 5)
}

method test(this: Ref)
  requires acc(this.i, 1 / 4 * (1 / 3)) && acc(this.i, 1 / 2 * (1 / 5 * (1 / 3))) {}

```

And that Hugh Jass AVL file passes verification too!!! Hopefully that means we've done nothing wrong now :pray: 