### PR TITLE
Check for recursive predicates using /all/ existing predicates.

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlinePredicatePlugin.scala
@@ -27,7 +27,7 @@ class InlinePredicatePlugin extends SilverPlugin with ParserPluginTemplate
   }
 
   override def beforeVerify(input: Program): Program = {
-    val allPredIds = input.predicates.collect{ case p if p.body.nonEmpty => p.name }.toSet
+    val allPredIds = input.predicates.map(_.name).toSet
     val recursivePreds = checkRecursive(allPredIds, input) ++ checkMutualRecursive(allPredIds, input)
     val recursivePredIds = recursivePreds.map(_.name)
     val predIdsCalledByRecursivePreds = recursivePreds.flatMap(nonRecursivePredsCalledBy(_, recursivePredIds, input))


### PR DESCRIPTION
This now passes instead of failing (lifted from [`silicon/0196.vpr`](https://github.com/jyoo980/silver/blob/master/src/test/resources/all/issues/carbon/0196.vpr):
```
predicate P(r: Ref) {forall e : Ref :: e in refs(r) ==> acc(Q(e), wildcard)}
predicate P2(r: Ref) {forall e : Ref :: e in refs(r) ==> acc(Q(e), 1/2)}
predicate R(r: Ref) {forall e : Ref :: e in refs(r) ==> acc(e.q, wildcard)}
predicate R2(r: Ref) {forall e : Ref :: e in refs(r) ==> acc(e.q, 1/2)}
predicate Q(r: Ref)
field q: Ref
function refs(r: Ref) : Set[Ref]
```
(See comment in #38)