### PR TITLE
Recursively call expandPredicate on current node.

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -41,7 +41,8 @@ trait InlineRewrite extends PredicateExpansion with InlineErrorChecker {
       case (expr@PredicateAccessPredicate(pred, perm), ctxt) =>
         if (cond(pred.predicateName)) {
           val optPredBody = propagatePermission(pred.predicateBody(program, ctxt), perm)
-          (optPredBody.get, ctxt)
+          val expandedExpr = expandExpression(optPredBody.get, member, program, cond)
+          (expandedExpr, ctxt)
         } else (expr, ctxt)
       case (scope: Scope, ctxt) =>
         (scope, ctxt ++ scope.scopedDecls.map(_.name).toSet)


### PR DESCRIPTION
Fixes #43. I must not have tested #20 after I did my last push, I don't think it actually fixed the problem :scream: 
Anyway the reason we need to do a recursive call on `expandPredicate` is because once the node is updated, it isn't revisited again; its _children_ are. The problem is that `optPredBody.get` could itself be a `PredicateAccessPredicate`, and we need to visit this very node again to resolve it.

N.B. We don't have this problem in any of the other functions in this file because whatever they produce, we only need to visit their children, not the same node again.

Tested on this:
```javascript
predicate A(this: Ref) {
  true && 0 == 0
}

predicate B(this: Ref) {
  A(this)
}

method test(this: Ref)
  requires B(this) {}
```
Gives this:
```javascript
method test(this: Ref)
  requires true && 0 == 0 {}
```