### PR TITLE
Some fixes

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
+++ b/src/main/scala/viper/silver/plugin/standard/inline/InlineRewrite.scala
@@ -75,6 +75,7 @@ trait InlineRewrite extends PredicateExpansion with InlineErrorChecker {
       case loop@While(_, invs, _) =>
         val expandedInvs = invs.map(expandExpression(_, member, program, cond))
         loop.copy(invs = expandedInvs)(pos = loop.pos, info = loop.info, errT = loop.errT)
+      case expr: Exp => removeUnfoldings(expr, cond)
     }, Traverse.TopDown).execute[Seqn](noFoldUnfoldStmts)
   }
 

--- a/vpr-test-files/unfolding.vpr
+++ b/vpr-test-files/unfolding.vpr
@@ -1,0 +1,20 @@
+field x: Bool
+
+predicate P(this: Ref) {
+  acc(this.x)
+}
+
+method testBefore(this: Ref)
+  requires P(this)
+{
+  var b: Bool
+  b := unfolding P(this) in this.x
+  if (unfolding P(this) in this.x) {
+      assert P(this)
+      while (unfolding P(this) in this.x)
+        invariant P(this) && unfolding P(this) in this.x
+      {
+        assert unfolding P(this) in this.x
+      }
+  }
+}


### PR DESCRIPTION
1. Expand `unfolding` expressions in all statements, not just when expressions are being expanded. The test file contains instances where they might occur, but originally we didn't do anything with them. I think it's actually possible to call `expandExpressions` directly, but I'm not really sure about the consequences of that, so only expanding unfoldings is a safe compromise I think.
2. It turns out that local variables are stored in the `Seqn`, which means we need to pass the names all throughout expansion so that they can be passed to `expandExpressions` and ultimately to any predicate expansions that we do in order to not accidentally have duplicate variable names.